### PR TITLE
Fix `.shutdown()` using a side thread.

### DIFF
--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -34,9 +34,10 @@ class CeleryExecutor(Executor):
         self._shutdown = False
         self._shutdown_lock = Lock()
         self._futures = {}
-        self._monitor = Thread(target=self._update_futures, daemon=True)
         self._monitor_started = False
         self._monitor_stopping = False
+        self._monitor = Thread(target=self._update_futures)
+        self._monitor.setDaemon(True)
 
     def _update_futures(self):
         while True:

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -1,16 +1,8 @@
-from concurrent.futures import Future, Executor, CancelledError, TimeoutError as FutureTimeoutError, as_completed
-from threading import Lock
-from weakref import WeakSet
+from concurrent.futures import Future, Executor, as_completed
+from threading import Lock, Thread
 import logging
-try:
-    from collections.abc import Callable
-except ImportError:
-    from collections import Callable    # Py27
-
-from future.utils import raise_with_traceback
 
 from celery import shared_task
-from celery.exceptions import TimeoutError as CeleryTimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -18,73 +10,6 @@ logger = logging.getLogger(__name__)
 @shared_task(serializer='pickle')
 def _celery_call(func, *args, **kwargs):
     return func(*args, **kwargs)
-
-
-class CeleryExecutorFuture(Future):
-    def __init__(self, asyncresult, *args, **kwargs):
-        super(CeleryExecutorFuture, self).__init__(*args, **kwargs)
-        self._ar = asyncresult
-        asyncresult.then(self._callback, on_error=self._error)
-        self._ar.ready()   # Just trigger the state update check
-
-    def __repr__(self):
-        self._ar.ready()   # Triggers an update check
-        return super(CeleryExecutorFuture, self).__repr__()
-
-    def cancel(self):
-        self._ar.revoke()
-        self._ar.ready()   # Triggers an update check
-
-        if self._ar.state == 'REVOKED':
-            return True
-        else:
-            return False
-
-    def cancelled(self):
-        self._ar.ready()   # Triggers an update check
-        return bool(self._ar.state == 'REVOKED')
-
-    def running(self):
-        self._ar.ready()   # Triggers an update check
-        return bool(self._ar.state in ['STARTED', 'RETRY'])
-
-    def done(self):
-        self._ar.ready()   # Triggers an update check
-        return bool(self._ar.state in ['SUCCESS', 'REVOKED', 'FAILURE'])
-
-    def result(self, timeout=None):
-        self._ar.ready()   # Triggers an update check
-
-        if self._ar.state == 'REVOKED':
-            raise CancelledError()
-
-        if timeout == 0:    # On Celery, 0 == None
-            timeout = 0.000000000001
-
-        try:
-            return self._ar.wait(timeout=timeout)  # Will (re)raise exception if occurred
-        except CeleryTimeoutError as err:
-            raise_with_traceback(FutureTimeoutError())
-
-    def exception(self, timeout=None):
-        if timeout == 0:    # On Celery, 0 == None
-            timeout = 0.000000000001
-
-        try:
-            self.result(timeout=timeout)   # Will trigger the update check
-        except (FutureTimeoutError, CancelledError):
-            raise
-        except BaseException as err:
-            return err  # Got the exception raised into the Future call
-        return None  # No exception raised
-
-    def _callback(self, asyncresult):
-        logger.debug('Celery task "%s" resolved.', asyncresult.id)
-        self.set_result(asyncresult.result)
-
-    def _error(self, asyncresult):
-        logger.debug('Celery task "%s" resolved with error.', asyncresult.id)
-        self.set_exception(asyncresult.result)
 
 
 class CeleryExecutor(Executor):
@@ -107,12 +32,59 @@ class CeleryExecutor(Executor):
         self._applyasync_kwargs = applyasync_kwargs or {}
         self._shutdown = False
         self._shutdown_lock = Lock()
-        self._futures = WeakSet()
+        self._futures = {}
+        self._monitor = Thread(target=self._update_futures, daemon=True)
+        self._monitor_started = False
+        self._monitor_stopping = False
+
+    def _update_futures(self):
+        while True:
+            if self._monitor_stopping:
+                return
+
+            for fut, ar in tuple(self._futures.items()):
+                if fut._state in ('FINISHED', 'CANCELLED_AND_NOTIFIED'):
+                    # This Future is set and done. Nothing else to do.
+                    self._futures.pop(fut)
+                    continue
+
+                ar.ready()   # Just trigger the AsyncResult state update check
+
+                if ar.state == 'REVOKED':
+                    logger.debug('Celery task "%s" canceled.', ar.id)
+                    if not fut.cancelled():
+                        assert fut.cancel(), 'Future was not running but failed to be cancelled'
+                        fut.set_running_or_notify_cancel()
+                    # Future is 'CANCELLED'
+
+                elif ar.state in ('RUNNING', 'RETRY'):
+                    logger.debug('Celery task "%s" running.', ar.id)
+                    if not fut.running():
+                        fut.set_running_or_notify_cancel()
+                    # Future is 'RUNNING'
+
+                elif ar.state == 'SUCCESS':
+                    logger.debug('Celery task "%s" resolved.', ar.id)
+                    fut.set_result(ar.get())
+                    # Future is 'FINISHED'
+
+                elif ar.state == 'FAILURE':
+                    logger.debug('Celery task "%s" resolved with error.', ar.id)
+                    fut.set_exception(ar.result)
+                    # Future is 'FINISHED'
+
+                # else:  # ar.state in [RECEIVED, STARTED, REJECTED, RETRY]
+                #     pass
 
     def submit(self, fn, *args, **kwargs):
         with self._shutdown_lock:
             if self._shutdown:
                 raise RuntimeError('cannot schedule new futures after shutdown')
+
+            if not self._monitor_started:
+                self._monitor.start()
+                self._monitor_started = True
+
             if self._predelay:
                 self._predelay(fn, *args, **kwargs)
             asyncresult = _celery_call.apply_async((fn,) + args, kwargs,
@@ -120,8 +92,9 @@ class CeleryExecutor(Executor):
             if self._postdelay:
                 self._postdelay(asyncresult)
 
-            future = CeleryExecutorFuture(asyncresult)
-            self._futures.add(future)
+            future = Future()
+            future._ar = asyncresult
+            self._futures[future] = asyncresult
             return future
 
     def shutdown(self, wait=True):
@@ -129,6 +102,15 @@ class CeleryExecutor(Executor):
             self._shutdown = True
             for fut in self._futures:
                 fut.cancel()
+        if wait:
+            for fut in as_completed(self._futures):
+                pass
+
+            self._monitor_stopping = True
+            try:
+                self._monitor.join()
+            except RuntimeError:
+                pass
 
 
 class SyncExecutor(Executor):

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -102,6 +102,7 @@ class CeleryExecutor(Executor):
             self._shutdown = True
             for fut in self._futures:
                 fut.cancel()
+
         if wait:
             for fut in as_completed(self._futures):
                 pass
@@ -110,6 +111,7 @@ class CeleryExecutor(Executor):
             try:
                 self._monitor.join()
             except RuntimeError:
+                # Thread never started. Cannot join
                 pass
 
 

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -18,6 +18,7 @@ class CeleryExecutor(Executor):
                     predelay=None,
                     postdelay=None,
                     applyasync_kwargs=None,
+                    update_delay=0.1,
                 ):
         """
         Executor implementation using a celery caller `_celery_call` wrapper
@@ -27,10 +28,12 @@ class CeleryExecutor(Executor):
             predelay: Will trigger before the `.apply_async` internal call
             postdelay: Will trigger before the `.apply_async` internal call
             applyasync_kwargs: Options passed to the `.apply_async()` call
+            update_delay: Delay time between checks for Future state changes
         """
         self._predelay = predelay
         self._postdelay = postdelay
         self._applyasync_kwargs = applyasync_kwargs or {}
+        self._update_delay = update_delay
         self._shutdown = False
         self._shutdown_lock = Lock()
         self._futures = {}
@@ -41,7 +44,7 @@ class CeleryExecutor(Executor):
 
     def _update_futures(self):
         while True:
-            time.sleep(0.1)  # Not-so-busy loop
+            time.sleep(self._update_delay)  # Not-so-busy loop
             if self._monitor_stopping:
                 return
 

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -1,6 +1,7 @@
 from concurrent.futures import Future, Executor, as_completed
 from threading import Lock, Thread
 import logging
+import time
 
 from celery import shared_task
 
@@ -39,6 +40,7 @@ class CeleryExecutor(Executor):
 
     def _update_futures(self):
         while True:
+            time.sleep(0.1)  # Not-so-busy loop
             if self._monitor_stopping:
                 return
 

--- a/tests/test_celery_executor.py
+++ b/tests/test_celery_executor.py
@@ -60,6 +60,19 @@ def test_excutors_parity(celery_session_worker):
 
     assert map_results == s_results == tp_results == cl_results
 
+    tp_exec.shutdown(wait=True)
+    s_exec.shutdown(wait=True)
+    cl_exec.shutdown(wait=True)
+
+
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, SyncExecutor, CeleryExecutor])
+def test_executors_shutdown_parity(executor_class, celery_session_worker):
+    executor = executor_class()
+
+    executor.shutdown()
+    with pytest.raises(RuntimeError):
+        executor.submit(pow, 2, 5)
+
 
 def test_excutor_exception_parity(celery_session_worker):
     tp_exec = ThreadPoolExecutor()
@@ -79,6 +92,10 @@ def test_excutor_exception_parity(celery_session_worker):
 
     with pytest.raises(IOError):
         list(cl_exec.map(open, operations))
+
+    tp_exec.shutdown(wait=True)
+    s_exec.shutdown(wait=True)
+    cl_exec.shutdown(wait=True)
 
 
 def test_futures_parity(celery_session_worker):
@@ -121,6 +138,9 @@ def test_futures_parity(celery_session_worker):
     for tp_fut_state, cel_fut_state in states:
         assert tp_fut_state == cel_fut_state
 
+    tp_exec.shutdown(wait=True)
+    cel_exec.shutdown(wait=True)
+
 
 ## Could not force a REVOKE on celery future! (or: I could not.)
 # def test_future_cancel_parity(celery_session_worker):
@@ -159,6 +179,9 @@ def test_future_exception_parity(celery_session_worker):
 
     assert tp_err.type == cel_err.type
     assert str(tp_err.value) == str(cel_err.value)
+
+    tp_exec.shutdown(wait=True)
+    cel_exec.shutdown(wait=True)
 
 
 def _collect_state(future):

--- a/tests/test_celery_executor.py
+++ b/tests/test_celery_executor.py
@@ -74,10 +74,9 @@ def test_executors_shutdown_parity(executor_class, celery_session_worker):
         executor.submit(pow, 2, 5)
 
 
-def test_excutor_exception_parity(celery_session_worker):
-    tp_exec = ThreadPoolExecutor()
-    s_exec = SyncExecutor()
-    cl_exec = CeleryExecutor()
+@pytest.mark.parametrize("executor_class", [ThreadPoolExecutor, SyncExecutor, CeleryExecutor])
+def test_executor_exception_parity(executor_class, celery_session_worker):
+    executor = executor_class()
 
     operations = ['/nonexistentfile', '/anothernonexistentfile']
 
@@ -85,17 +84,9 @@ def test_excutor_exception_parity(celery_session_worker):
         list(map(open, operations))
 
     with pytest.raises(IOError):
-        list(tp_exec.map(open, operations))
+        list(executor.map(open, operations))
 
-    with pytest.raises(IOError):
-        list(s_exec.map(open, operations))
-
-    with pytest.raises(IOError):
-        list(cl_exec.map(open, operations))
-
-    tp_exec.shutdown(wait=True)
-    s_exec.shutdown(wait=True)
-    cl_exec.shutdown(wait=True)
+    executor.shutdown(wait=True)
 
 
 def test_futures_parity(celery_session_worker):


### PR DESCRIPTION
Track all Future created and use a side thread to check and propagate AsyncResult state changes to its  Futures. Got rid of the non-standard Future subclass.

The `.shutdown()` waits all Future to settle and `.join()` the side thread.

I tried to find a way to renice the side thread but can't find a way. Then introduced a 100ms delay between loops. This is configurable via `update_delay` arg.