### PR TITLE
Fix `.cancel()` calls

### DIFF
--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -23,11 +23,6 @@ class CeleryExecutorFuture(Future):
         Returns True if the future was cancelled, False otherwise. A future
         cannot be cancelled if it is running or has already completed.
         """
-        ## Note that this method does not call super()
-        # Its because the place where ._ar.revoke() should be called is
-        # in the middle of the Future.cancel() code.
-        # Solved by copying and adapting from stdlib
-        # See: https://github.com/python/cpython/blob/087570af6d5d39b51bdd5e660a53903960e58678/Lib/concurrent/futures/_base.py#L352-L369
         with self._condition:
             if self._state in ['RUNNING', 'FINISHED', 'CANCELLED', 'CANCELLED_AND_NOTIFIED']:
                 return super(CeleryExecutorFuture, self).cancel()

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -13,10 +13,10 @@ def _celery_call(func, *args, **kwargs):
     return func(*args, **kwargs)
 
 
-class CeleryFuture(Future):
+class CeleryExecutorFuture(Future):
     def __init__(self, asyncresult):
         self._ar = asyncresult
-        super(CeleryFuture, self).__init__()
+        super(CeleryExecutorFuture, self).__init__()
 
     def cancel(self):
         """Cancel the future if possible.
@@ -138,7 +138,7 @@ class CeleryExecutor(Executor):
             if self._postdelay:
                 self._postdelay(asyncresult)
 
-            future = CeleryFuture(asyncresult)
+            future = CeleryExecutorFuture(asyncresult)
             self._futures[future] = asyncresult
             return future
 


### PR DESCRIPTION
(depends on `fix-shutdown` from #10)

To implement `.cancel()` in a simple way, CeleryExecutor changed to be using a subclass of Future: `CeleryExecutorFuture`

Unfortunately, the official implementation have not a way/hook to insert the `AsyncResult.revoke()` call. Then the subclass was needed.

...or reimplement the whole module to resemble the two-queues-in-outs of ThreadPoolExecutor. Not now.