### PR TITLE
Every AsyncResult should be called .get() or .forget()

### DIFF
--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -19,6 +19,10 @@ class CeleryExecutorFuture(Future):
         self._ar = asyncresult
         super(CeleryExecutorFuture, self).__init__()
 
+    def __del__(self):
+        self._ar.forget()
+        del self._ar
+
     def cancel(self):
         """Cancel the future if possible.
         Returns True if the future was cancelled, False otherwise. A future


### PR DESCRIPTION
The CeleryExecutorFuture._ar should be called .forget() on its destructor, triggering a release of resources on the result backend.

This is demanded by the Celery documentation.
See: http://docs.celeryproject.org/en/latest/reference/celery.result.html#celery.result.AsyncResult.get