### PR TITLE
allowing executor to run with subtasks

### DIFF
--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -114,7 +114,7 @@ class CeleryExecutor(Executor):
 
                 elif ar.state == 'SUCCESS':
                     logger.debug('Celery task "%s" resolved.', ar.id)
-                    fut.set_result(ar.get())
+                    fut.set_result(ar.get(disable_sync_subtasks=False))
                     # Future is FINISHED
 
                 elif ar.state == 'FAILURE':


### PR DESCRIPTION
Allowing execution with subtasks. Not recommended by celery, but necessary in some cases.