### PR TITLE
Retry failed submissions, possibily on a different queue

### DIFF
--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -60,14 +60,8 @@ class CeleryExecutorFuture(Future):
 
 
 class CeleryExecutor(Executor):
-    def __init__(self,
-                 predelay=None,
-                 postdelay=None,
-                 applyasync_kwargs=None,
-                 retry_kwargs=None,
-                 retry_queue='',
-                 update_delay=0.1,
-                 ):
+    def __init__(self, predelay=None, postdelay=None, applyasync_kwargs=None,
+                 retry_kwargs=None, retry_queue='', update_delay=0.1):
         """
         Executor implementation using a celery caller `_celery_call` wrapper
         around the submitted tasks.

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -65,6 +65,7 @@ class CeleryExecutor(Executor):
                     postdelay=None,
                     applyasync_kwargs=None,
                     retry_kwargs=None,
+                    retry_queue='',
                     update_delay=0.1,
                 ):
         """
@@ -81,6 +82,8 @@ class CeleryExecutor(Executor):
         self._postdelay = postdelay
         self._applyasync_kwargs = applyasync_kwargs or {}
         self._retry_kwargs = retry_kwargs or {'max_retries': 0}
+        if retry_queue:
+            self._retry_kwargs['queue'] = retry_queue
         self._update_delay = update_delay
         self._shutdown = False
         self._shutdown_lock = Lock()

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -45,7 +45,7 @@ class CeleryExecutorFuture(Future):
             # Celery task should be REVOKED now. Otherwise may be not possible revoke it.
             if self._ar.state == 'REVOKED':
                 result = super(CeleryExecutorFuture, self).cancel()
-                assert result == True, 'Please open an issue on Github: Upstream implementation changed?'
+                assert result is True, 'Please open an issue on Github: Upstream implementation changed?'
             else:
                 # Is not running nor revoked nor finished :/
                 # The revoke() had not produced effect: Task is probable not on a worker, then not revoke-able.
@@ -53,7 +53,7 @@ class CeleryExecutorFuture(Future):
                 initial_state = self._state
                 self._state = RUNNING
                 result = super(CeleryExecutorFuture, self).cancel()
-                assert result == False, 'Please open an issue on Github: Upstream implementation changed?'
+                assert result is False, 'Please open an issue on Github: Upstream implementation changed?'
                 self._state = initial_state
 
             return result
@@ -61,13 +61,13 @@ class CeleryExecutorFuture(Future):
 
 class CeleryExecutor(Executor):
     def __init__(self,
-                    predelay=None,
-                    postdelay=None,
-                    applyasync_kwargs=None,
-                    retry_kwargs=None,
-                    retry_queue='',
-                    update_delay=0.1,
-                ):
+                 predelay=None,
+                 postdelay=None,
+                 applyasync_kwargs=None,
+                 retry_kwargs=None,
+                 retry_queue='',
+                 update_delay=0.1,
+                 ):
         """
         Executor implementation using a celery caller `_celery_call` wrapper
         around the submitted tasks.
@@ -113,7 +113,7 @@ class CeleryExecutor(Executor):
                     continue
 
                 ar = fut._ar
-                ar.ready()   # Just trigger the AsyncResult state update check
+                ar.ready()  # Just trigger the AsyncResult state update check
 
                 if ar.state == 'REVOKED':
                     logger.debug('Celery task "%s" canceled.', ar.id)
@@ -172,7 +172,7 @@ class CeleryExecutor(Executor):
                 fut.cancel()
 
         if wait:
-            for fut in as_completed(self._futures):
+            for _ in as_completed(self._futures):
                 pass
 
             self._monitor_stopping = True
@@ -193,6 +193,7 @@ class SyncExecutor(Executor):
 
     Based on a snippet from https://stackoverflow.com/a/10436851/798575
     """
+
     def __init__(self, lock=Lock):
         self._shutdown = False
         self._shutdown_lock = lock()

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -76,14 +76,19 @@ class CeleryExecutor(Executor):
             predelay: Will trigger before the `.apply_async` internal call
             postdelay: Will trigger before the `.apply_async` internal call
             applyasync_kwargs: Options passed to the `.apply_async()` call
+            retry_kwargs: Options passed to the `.retry()` call on errors
+            retry_queue: Sugar to set an alternative queue specially for errors
             update_delay: Delay time between checks for Future state changes
         """
+        # Options about calling the Task
         self._predelay = predelay
         self._postdelay = postdelay
         self._applyasync_kwargs = applyasync_kwargs or {}
         self._retry_kwargs = retry_kwargs or {'max_retries': 0}
         if retry_queue:
             self._retry_kwargs['queue'] = retry_queue
+
+        # Options about managing this Executor flow
         self._update_delay = update_delay
         self._shutdown = False
         self._shutdown_lock = Lock()

--- a/celery_executor/executors.py
+++ b/celery_executor/executors.py
@@ -84,9 +84,11 @@ class CeleryExecutor(Executor):
         self._predelay = predelay
         self._postdelay = postdelay
         self._applyasync_kwargs = applyasync_kwargs or {}
-        self._retry_kwargs = retry_kwargs or {'max_retries': 0}
+        self._retry_kwargs = retry_kwargs or {}
         if retry_queue:
             self._retry_kwargs['queue'] = retry_queue
+            self._retry_kwargs.setdefault('max_retries', 1)
+        self._retry_kwargs.setdefault('max_retries', 0)
 
         # Options about managing this Executor flow
         self._update_delay = update_delay


### PR DESCRIPTION
This allows a dead-letter queue to be set easily, for retries of failed submissions